### PR TITLE
Updated to have feature parity with base game

### DIFF
--- a/BigStorage/BigBeautifulStorageLockerConfig.cs
+++ b/BigStorage/BigBeautifulStorageLockerConfig.cs
@@ -49,10 +49,13 @@ namespace BigStorage
             storage.storageFilters = STORAGEFILTERS.NOT_EDIBLE_SOLIDS;
             storage.storageFullMargin = STORAGE.STORAGE_LOCKER_FILLED_MARGIN;
             storage.fetchCategory = Storage.FetchCategory.GeneralStorage;
+            storage.showCapacityStatusItem = true;
             storage.showCapacityAsMainStatus = true;
             CopyBuildingSettings copyBuildingSettings = go.AddOrGet<CopyBuildingSettings>();
             copyBuildingSettings.copyGroupTag = GameTags.StorageLocker;
             go.AddOrGet<StorageLocker>();
+            go.AddOrGet<UserNameable>();
+            go.AddOrGetDef<RocketUsageRestriction.Def>();
         }
 
         // Token: 0x06006420 RID: 25632 RVA: 0x001EE6AA File Offset: 0x001ECAAA

--- a/BigStorage/BigGasStorageConfig.cs
+++ b/BigStorage/BigGasStorageConfig.cs
@@ -44,6 +44,12 @@ namespace BigStorage
             buildingDef.AudioCategory = "HollowMetal";
             buildingDef.UtilityInputOffset = new CellOffset(1, 2);
             buildingDef.UtilityOutputOffset = new CellOffset(0, 0);
+            buildingDef.LogicOutputPorts = new List<LogicPorts.Port>()
+            {
+                LogicPorts.Port.OutputPort(SmartReservoir.PORT_ID, new CellOffset(0, 0), (string) STRINGS.BUILDINGS.PREFABS.SMARTRESERVOIR.LOGIC_PORT, (string) STRINGS.BUILDINGS.PREFABS.SMARTRESERVOIR.LOGIC_PORT_ACTIVE, (string) STRINGS.BUILDINGS.PREFABS.SMARTRESERVOIR.LOGIC_PORT_INACTIVE)
+            };
+            GeneratedBuildings.RegisterWithOverlay(OverlayScreen.GasVentIDs, "GasReservoir");
+
             return buildingDef;
         }
 
@@ -56,7 +62,9 @@ namespace BigStorage
             storage.storageFilters = STORAGEFILTERS.GASES;
             storage.capacityKg = BigStorageConfigMod._configManager.Config.BigGasLockerCapacity;
             storage.SetDefaultStoredItemModifiers(GasReservoirConfig.ReservoirStoredItemModifiers);
+            storage.showCapacityStatusItem = true;
             storage.showCapacityAsMainStatus = true;
+            go.AddOrGet<SmartReservoir>();
             ConduitConsumer conduitConsumer = go.AddOrGet<ConduitConsumer>();
             conduitConsumer.conduitType = ConduitType.Gas;
             conduitConsumer.ignoreMinMassCheck = true;
@@ -72,6 +80,7 @@ namespace BigStorage
         public override void DoPostConfigureComplete(GameObject go)
         {
             go.AddOrGetDef<StorageController.Def>();
+            go.GetComponent<KPrefabID>().AddTag(GameTags.OverlayBehindConduits);
         }
 
 

--- a/BigStorage/BigLiquidStorageConfig.cs
+++ b/BigStorage/BigLiquidStorageConfig.cs
@@ -1,4 +1,5 @@
-﻿using TUNING;
+﻿using System.Collections.Generic;
+using TUNING;
 using UnityEngine;
 
 namespace BigStorage
@@ -37,6 +38,11 @@ namespace BigStorage
             buildingDef.AudioCategory = "HollowMetal";
             buildingDef.UtilityInputOffset = new CellOffset(1, 2);
             buildingDef.UtilityOutputOffset = new CellOffset(0, 0);
+            buildingDef.LogicOutputPorts = new List<LogicPorts.Port>()
+            {
+                LogicPorts.Port.OutputPort(SmartReservoir.PORT_ID, new CellOffset(0, 0), (string) STRINGS.BUILDINGS.PREFABS.SMARTRESERVOIR.LOGIC_PORT, (string) STRINGS.BUILDINGS.PREFABS.SMARTRESERVOIR.LOGIC_PORT_ACTIVE, (string) STRINGS.BUILDINGS.PREFABS.SMARTRESERVOIR.LOGIC_PORT_INACTIVE)
+            };
+
             return buildingDef;
         }
 
@@ -50,7 +56,9 @@ namespace BigStorage
             storage.storageFilters = STORAGEFILTERS.LIQUIDS;
             storage.capacityKg = BigStorageConfigMod._configManager.Config.BigLiquidStorageCapacity;
             storage.SetDefaultStoredItemModifiers(GasReservoirConfig.ReservoirStoredItemModifiers);
+            storage.showCapacityStatusItem = true;
             storage.showCapacityAsMainStatus = true;
+            go.AddOrGet<SmartReservoir>();
             ConduitConsumer conduitConsumer = go.AddOrGet<ConduitConsumer>();
             conduitConsumer.conduitType = ConduitType.Liquid;
             conduitConsumer.ignoreMinMassCheck = true;
@@ -66,6 +74,7 @@ namespace BigStorage
         public override void DoPostConfigureComplete(GameObject go)
         {
             go.AddOrGetDef<StorageController.Def>();
+            go.GetComponent<KPrefabID>().AddTag(GameTags.OverlayBehindConduits);
         }
 
     }

--- a/BigStorage/BigStorageLockerConfig .cs
+++ b/BigStorage/BigStorageLockerConfig .cs
@@ -49,6 +49,7 @@ namespace BigStorage
             storage.storageFilters = STORAGEFILTERS.NOT_EDIBLE_SOLIDS;
             storage.storageFullMargin = STORAGE.STORAGE_LOCKER_FILLED_MARGIN;
             storage.fetchCategory = Storage.FetchCategory.GeneralStorage;
+            storage.showCapacityStatusItem = true;
             storage.showCapacityAsMainStatus = true;
             CopyBuildingSettings copyBuildingSettings = go.AddOrGet<CopyBuildingSettings>();
             copyBuildingSettings.copyGroupTag = GameTags.StorageLocker;


### PR DESCRIPTION
I was working with the automation, and noticed a mismatch in functionality with the base Liquide storage module.

By decompiling the source code I compared base storages to the mod, and added the missing components. 

Updated Big Gas Storage to have feature parity with base game
Updated Big Liquid Storage to have feature parity with base game
Updated Big Beautiful Storage Locker to have feature parity with base game
Updated Big Storage Locker to have feature parity with base game