### PR TITLE
Added support for in-game Mod Options (Experimental)

### DIFF
--- a/BigStorage/BigStorage.csproj
+++ b/BigStorage/BigStorage.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -45,6 +45,9 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PLib, Version=4.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PLib.4.7.0\lib\net471\PLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BigStorage/BigStorageMod.cs
+++ b/BigStorage/BigStorageMod.cs
@@ -4,6 +4,7 @@ using CaiLib.Config;
 using CaiLib;
 using System;
 using System.Collections.Generic;
+using PeterHan.PLib.Options;
 
 namespace BigStorage
 {
@@ -21,9 +22,11 @@ namespace BigStorage
 		public override void OnLoad(Harmony harmony)
 		{
 			CaiLib.Logger.Logger.LogInit();
-			BigStorageConfigMod._configManager = new ConfigManager<Config>(null, "config.json");
+            POptions pOptions = new POptions();
+            pOptions.RegisterOptions(this, typeof(Config));
+            BigStorageConfigMod._configManager = new ConfigManager<Config>(null, "config.json");
 			BigStorageConfigMod._configManager.ReadConfig(null);
-               harmony.PatchAll();
+            harmony.PatchAll();
         }
 
 

--- a/BigStorage/Config.cs
+++ b/BigStorage/Config.cs
@@ -9,36 +9,30 @@ namespace BigStorage
     [RestartRequired]
     public class Config : SingletonOptions<Config>
     {
-		[JsonProperty]
-        [Option("Big Storage Locker Capacity (kg)", "Determines the capacity of the Big Storage Locker in kg.", Format = "F1")]
-        [Limit(1f, 1000000f)]
+        // Capacity
+        [JsonProperty] [Option("Big Storage Locker Capacity (kg)", "Determines the capacity of the Big Storage Locker in kg.", Format = "F1")] [Limit(1f, 1000000f)]
         public float BigStorageLockerCapacity { get; set; } = 100000f;
-
-        [JsonProperty]
-        [Option("Big Beautiful Storage Locker Capacity (kg)", "Determines the capacity of the Big Beautiful Storage Locker in kg.", Format = "F1")]
-        [Limit(1f, 1000000f)]
+        [JsonProperty] [Option("Big Beautiful Storage Locker Capacity (kg)", "Determines the capacity of the Big Beautiful Storage Locker in kg.", Format = "F1")] [Limit(1f, 1000000f)]
         public float BigBeautifulStorageLockerCapacity { get; set; } = 100000f;
-
-        [JsonProperty]
-        [Option("Big Gas Container Capacity (kg)", "Determines the capacity of the Big Gas Container in kg.", Format = "F1")]
-        [Limit(1f, 1000000f)]
+        [JsonProperty] [Option("Big Gas Container Capacity (kg)", "Determines the capacity of the Big Gas Container in kg.", Format = "F1")] [Limit(1f, 1000000f)]
         public float BigGasLockerCapacity { get; set; } = 750f;
+        [JsonProperty] [Option("Big Liquid Storage Capacity (kg)", "Determines the capacity of the Big Liquid Storage in kg.", Format = "F1")] [Limit(1f, 1000000f)]
+        public float BigLiquidStorageCapacity { get; set; } = 25000f; 
         
-        [JsonProperty]
-        [Option("Big Liquid Storage Capacity (kg)", "Determines the capacity of the Big Liquid Storage in kg.", Format = "F1")]
-        [Limit(1f, 1000000f)]
-        public float BigLiquidStorageCapacity { get; set; } = 25000f;
-		[JsonProperty]
-		public byte Red { get; set; } = 0;
-		[JsonProperty]
+        // Colour
+        [JsonProperty] [Option("Red", "Set the RED tint for the Big Storages.", Format = "F1")] [Limit(0f, 255f)]
+        public byte Red { get; set; } = 0;
+        [JsonProperty] [Option("Green", "Set the GREEN tint for the Big Storages.", Format = "F1")] [Limit(0f, 255f)]
 		public byte Green { get; set; } = 150;
-		[JsonProperty]
+        [JsonProperty] [Option("Blue", "Set the BLUE tint for the Big Storages.", Format = "F1")] [Limit(0f, 255f)]
 		public byte Blue { get; set; } = 255;
-        [JsonProperty]
+
+        //Colour Beautiful
+        [JsonProperty] [Option("Red", "Set the RED tint for the Big Beautiful Storages.", Format = "F1")] [Limit(0f, 255f)]
 		public byte BeautifulRed { get; set; } = 200;
-		[JsonProperty]
+        [JsonProperty] [Option("Red", "Set the GREEN tint for the Big Beautiful Storages.", Format = "F1")] [Limit(0f, 255f)]
 		public byte BeautifulGreen { get; set; } = 0;
-		[JsonProperty]
+        [JsonProperty] [Option("Red", "Set the BLUE tint for the Big Beautiful Storages.", Format = "F1")] [Limit(0f, 255f)]
 		public byte BeautifulBlue { get; set; } = 255;
 	}
 }

--- a/BigStorage/Config.cs
+++ b/BigStorage/Config.cs
@@ -1,18 +1,32 @@
 ﻿using System;
 using Newtonsoft.Json;
+using PeterHan.PLib.Options;
 
 namespace BigStorage
 {
 	// Token: 0x02000003 RID: 3
-	public class Config
-	{
+    [Serializable]
+    [RestartRequired]
+    public class Config : SingletonOptions<Config>
+    {
 		[JsonProperty]
-		public float BigStorageLockerCapacity { get; set; } = 100000f;
-		[JsonProperty]
-		public float BigGasLockerCapacity { get; set; } = 750f;
-		[JsonProperty]
-		public float BigLiquidStorageCapacity { get; set; } = 25000f;
-		[JsonProperty]
-		public float BigBeautifulStorageLockerCapacity { get; set; } = 100000f;
-	}
+        [Option("Big Storage Locker Capacity (kg)", "Determines the capacity of the Big Storage Locker in kg.", Format = "F1")]
+        [Limit(1f, 1000000f)]
+        public float BigStorageLockerCapacity { get; set; } = 100000f;
+
+        [JsonProperty]
+        [Option("Big Beautiful Storage Locker Capacity (kg)", "Determines the capacity of the Big Beautiful Storage Locker in kg.", Format = "F1")]
+        [Limit(1f, 1000000f)]
+        public float BigBeautifulStorageLockerCapacity { get; set; } = 100000f;
+
+        [JsonProperty]
+        [Option("Big Gas Container Capacity (kg)", "Determines the capacity of the Big Gas Container in kg.", Format = "F1")]
+        [Limit(1f, 1000000f)]
+        public float BigGasLockerCapacity { get; set; } = 750f;
+        
+        [JsonProperty]
+        [Option("Big Liquid Storage Capacity (kg)", "Determines the capacity of the Big Liquid Storage in kg.", Format = "F1")]
+        [Limit(1f, 1000000f)]
+        public float BigLiquidStorageCapacity { get; set; } = 25000f;
+    }
 }

--- a/BigStorage/packages.config
+++ b/BigStorage/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net471" />
+  <package id="PLib" version="4.7.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
This adds the ability for a user to change the mod options in the main menu. I have tested it superficially, and it seems to work well for the capacity of storages. I have not been able to get the colour working yet.

(Starting without config.json file works. Gets standard values. Loading with works as well.)

- Added Mod menu support
- Changed max storage capacity allowed is 1.000.000 kg via in-game slider
- Changed order of Big Storage Locker to be next to BBSL
